### PR TITLE
ignore metal3-io/cluster-api-provider-metal3

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -119,7 +119,8 @@ $github_to_jira \
     -jira-component 'KNI Deploy Install' \
     \
     -github-org metal3-io \
-    -github-ignore metal3-io.github.io
+    -github-ignore metal3-io.github.io \
+    -github-ignore cluster-api-provider-metal3
 
 header "Importing openshift-metal3 items for the UX team"
 $github_to_jira \


### PR DESCRIPTION
We don't use the repo or its contents.