### PR TITLE
clean up logging output

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 
-set -exu
+set -eu
 
 BINDIR=$(dirname $0)
-
-# Log output automatically
-# LOGDIR="$HOME/jira-sync-logs"
-# if [ ! -d "$LOGDIR" ]; then
-#     mkdir -p "$LOGDIR"
-# fi
-# LOGFILE="$LOGDIR/$(date +%F-%H%M%S).log"
-# echo "Logging to $LOGFILE"
-# # Set fd 1 and 2 to write to the log file
-# exec 1> >( tee "${LOGFILE}" ) 2>&1
 
 echo "Starting $(date +%F-%H%M%S)"
 


### PR DESCRIPTION
Remove set -x

Remove unused code to log to a file, now that the container system
collects that data.