### PR TITLE
ignore the metal3-io/hardware-classification-controller repo

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -113,7 +113,7 @@ $github_to_jira \
     -jira-component 'KNI Deploy Install' \
     \
     -github-org metal3-io \
-    -github-ignore metal3-io.github.io,cluster-api-provider-metal3
+    -github-ignore metal3-io.github.io,cluster-api-provider-metal3,hardware-classification-controller
 
 header "Importing openshift-metal3 items for the UX team"
 $github_to_jira \


### PR DESCRIPTION
OpenShift does not use the hardware-classification-controller, yet.