### PR TITLE
bugzilla: don't ignore API errors, and use API key

### DIFF
--- a/bugzilla-one/main.go
+++ b/bugzilla-one/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -32,7 +33,9 @@ type bug struct {
 }
 
 type bugSet struct {
-	Bugs []bug `json:"bugs"`
+	Error   bool   `json:"error"`
+	Message string `json:"message"`
+	Bugs    []bug  `json:"bugs"`
 }
 
 func processAllIssues(args syncArgs) error {
@@ -72,6 +75,10 @@ func processAllIssues(args syncArgs) error {
 		err = json.Unmarshal(body, &theBugs)
 		if err != nil {
 			return fmt.Errorf("Unable to parse bugzilla response for description: %s: %s", body, err)
+		}
+
+		if theBugs.Error {
+			return errors.New(theBugs.Message)
 		}
 
 		for _, bug := range theBugs.Bugs {

--- a/bugzilla-one/main.go
+++ b/bugzilla-one/main.go
@@ -48,6 +48,7 @@ func processAllIssues(args syncArgs) error {
 	for _, bugID := range args.bugzillaIDs {
 		q := url.Values{}
 		q.Set("include_fields", "id,summary,description")
+		q.Set("api_key", args.bugzillaToken)
 		parsedURL.RawQuery = q.Encode()
 		parsedURL.Path = fmt.Sprintf("%s/rest/bug/%s", parsedURL.Path, bugID)
 


### PR DESCRIPTION
Bugzilla sometimes returns a 200 status code while the JSON response
has a

```json
{
   ...
   "error": true,
   "message": "..."
}```

and the `link_one.sh` script silently fails.